### PR TITLE
fix stream abort() when sink has no end()

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -146,7 +146,7 @@ Stream.prototype.abort = function (err) {
   this.ended = err || true
   var i = this.blocks.streams.indexOf(this)
   if (~i) this.blocks.streams.splice(i, 1)
-  if (!this.sink.ended)
+  if (!this.sink.ended && this.sink.end)
     this.sink.end(err === true ? null : err)
 }
 


### PR DESCRIPTION
The newly added `tape('close')` test with the previous implementation was failing with:

```
# close
/home/async-flumelog/stream.js:150
    this.sink.end(err === true ? null : err)
              ^

TypeError: this.sink.end is not a function
    at Stream.abort (/home/async-flumelog/stream.js:150:15)
    at blocks.getBlock (/home/async-flumelog/stream.js:134:12)
    at Object.getBlock (/home/async-flumelog/index.js:95:7)
    at Stream._resume (/home/async-flumelog/stream.js:123:15)
    at Stream._next (/home/async-flumelog/node_modules/.pnpm/looper@4.0.0/node_modules/looper/index.js:11:9)
    at Stream.resume (/home/async-flumelog/stream.js:140:8)
    at Stream.pipe (/home/async-flumelog/node_modules/.pnpm/push-stream@11.0.0/node_modules/push-stream/pipe.js:19:25)
    at Test.<anonymous> (/home/async-flumelog/test/stream.js:95:29)
    at Test.bound [as _cb] (/home/async-flumelog/node_modules/.pnpm/tape@5.0.1/node_modules/tape/lib/test.js:84:32)
    at Test.run (/home/async-flumelog/node_modules/.pnpm/tape@5.0.1/node_modules/tape/lib/test.js:101:31)
 ERROR  Test failed. See above for more details.
```

A simple check for the `end` function fixes this issue.