### PR TITLE
Auto fix latest block if corrupted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Async flumelog
 
 This module is heavily inspired by [flumelog-aligned-offset]. It is an
-attempt to implement the same concept but in a simpler fashion,
-making it easier to reason about the code.
-Flumelog is the lowest part of the SSB stack, so it should
-extremly stable while still maintaining good performance.
+attempt to implement the same concept but in a simpler fashion, making
+it easier to reason about the code.  Flumelog is the lowest part of
+the SSB stack, so it should extremly stable while still maintaining
+good performance.
 
 An async flumelog consists of a number of `blocks`, that contain a
 number of `record`s. A `record` is simply it's `length`, as a 16-bit
@@ -21,19 +21,34 @@ space at the end of a block.  Blocks are always written in full.
 </block>*
 ```
 
-In contrast to flumelog-aligned-offset there is no additional `length` after the
-`data` in a `record` and no pointer at the end of a `block`. These were there to
-be able to iterate over the log in reverse, but I have never seen the need for
-that.
+In contrast to flumelog-aligned-offset there is no additional `length`
+after the `data` in a `record` and no pointer at the end of a
+`block`. These were there to be able to iterate over the log in
+reverse, but I have never seen the need for that.
 
 Writing to the log is always async. Note this is different from
-[flumelog-offset] and [flumelog-aligned-offset]. The `since` observable
-will be updated once the data is written. The `onDrain` callback can be used to
-know when data has been written if needed. Streaming will only emit
-values that have been written to storage. This is to ensure that a
-view will never get ahead of the main log and thus end up in a bad
-state if the system crashes before data is written. `get` will return
-values that have not been written to disk yet.
+[flumelog-offset] and [flumelog-aligned-offset]. The `since`
+observable will be updated once the data is written. The `onDrain`
+callback can be used to know when data has been written if
+needed. Streaming will only emit values that have been written to
+storage. This is to ensure that a view will never get ahead of the
+main log and thus end up in a bad state if the system crashes before
+data is written. `get` will return values that have not been written
+to disk yet.
+
+## Options
+
+```
+var OffsetLog = require('async-flumelog')
+var log = OffsetLog('/data/log', {
+  blockSize: 1024,          // default is 1024*64
+  codec: {encode, decode}   // defaults to no codec, expects buffers. for json use flumecodec/json
+  writeTimeout: 100         // default is 250. Amount of time to wait between writes
+  validateRecord: (d) => {} // default is no validate. A custom function that takes a message and
+                            // runs a custom validation to ensure the record is valid.
+                            // On load, all records in the latest block will be checked using this
+})
+```
 
 ## Benchmarks
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "push-stream-to-pull-stream": "^1.0.3"
   },
   "devDependencies": {
+    "bipf": "^1.4.0",
     "bench-flumelog": "^2.0.0",
     "cont": "^1.0.3",
     "flumecodec": "0.0.1",
@@ -32,6 +33,8 @@
     "test": "set -e; for t in test/*.js; do node $t; done"
   },
   "author": "Anders Rune Jensen <arj03@protonmail.ch>",
-  "contributors": ["Andre Staltz <contact@staltz.com>"],
+  "contributors": [
+    "Andre Staltz <contact@staltz.com>"
+  ],
   "license": "LGPL-3.0"
 }

--- a/test/jacob.js
+++ b/test/jacob.js
@@ -87,9 +87,6 @@ tape('length corruption', function (t) {
   const bipf1 = toBIPF({ text: 'testing' })
   const bipf2 = toBIPF({ bool: true, test: 'testing2' })
 
-  console.log("bipf1", bipf1.length)
-  console.log("bipf2", bipf2.length)
-  
   block.writeUInt16LE(bipf1.length, 0)
   bipf1.copy(block, 2)
   block.writeUInt16LE(65534, 2+bipf1.length)

--- a/test/jacob.js
+++ b/test/jacob.js
@@ -1,0 +1,155 @@
+const tape = require('tape')
+const fs = require('fs')
+const bipf = require('bipf')
+const RAF = require('polyraf')
+const Log = require('../')
+
+function toBIPF(msg) {
+  const len = bipf.encodingLength(msg)
+  const buf = Buffer.alloc(len)
+  bipf.encode(msg, buf, 0)
+  return buf
+}
+
+tape('corrupt message', function (t) {
+  var file = '/tmp/jacob.log'
+  try { fs.unlinkSync(file) } catch (_) {}
+  var db = Log(file, {blockSize: 64*1024})
+
+  var bipf1 = toBIPF({ text: 'testing' })
+  var bipf2 = toBIPF({ bool: true, test: 'testing2' })
+  bipf2[7] = '!' // corrupt the message
+  
+  db.append(bipf1, function (err, offset1) {
+    if(err) throw err
+    db.append(bipf2, function (err, offset2) {
+      if(err) throw err
+
+      db.close(t.end)
+    })
+  })
+})
+
+tape('corrupt message re-read without validation', function (t) {
+  var file = '/tmp/jacob.log'
+  var db = Log(file, {blockSize: 64*1024})
+  
+  db.onReady(() => {
+    var result = []
+    
+    db.stream({seqs: false}).pipe({
+      paused: false,
+      write: function (e) { result.push(e) },
+      end: function() {
+        // because these are just buffers we won't see the corruption
+        t.equal(result.length, 2)
+        db.close(t.end)
+      }
+    })
+  })
+})
+
+tape('corrupt message re-read with validation', function (t) {
+  var file = '/tmp/jacob.log'
+  var db = Log(file, {
+    blockSize: 64*1024,
+    validateRecord: (d) => {
+      try {
+        bipf.decode(d, 0)
+        return true
+      } catch (ex) {
+        return false
+      }
+    }
+  })
+  
+  db.onReady(() => {
+    var result = []
+    
+    db.stream({seqs: false}).pipe({
+      paused: false,
+      write: function (e) { result.push(e) },
+      end: function() {
+        t.equal(result.length, 1)
+        db.close(t.end)
+      }
+    })
+  })
+})
+
+tape('length corruption', function (t) {
+  let file = '/tmp/jacob-length.log'
+  try { fs.unlinkSync(file) } catch (_) {}
+
+  var raf = RAF(file)
+  let block = Buffer.alloc(64*1024)
+
+  const bipf1 = toBIPF({ text: 'testing' })
+  const bipf2 = toBIPF({ bool: true, test: 'testing2' })
+
+  console.log("bipf1", bipf1.length)
+  console.log("bipf2", bipf2.length)
+  
+  block.writeUInt16LE(bipf1.length, 0)
+  bipf1.copy(block, 2)
+  block.writeUInt16LE(65534, 2+bipf1.length)
+  bipf2.copy(block, 2+bipf1.length+2)
+  
+  raf.write(0, block, (err) => {
+    raf.close(t.end())
+  })
+})
+
+tape('length re-read without validation', function (t) {
+  var file = '/tmp/jacob-length.log'
+  var db = Log(file, {
+    blockSize: 64*1024
+  })
+  
+  db.onReady(() => {
+    var result = []
+    
+    db.stream({seqs: false}).pipe({
+      paused: false,
+      write: function (e) { result.push(e) },
+      end: function() {
+        t.equal(result.length, 1)
+
+        // append a fixed record
+        const bipf2 = toBIPF({ bool: true, test: 'testing2' })
+        db.append(bipf2, function (err) {
+          t.error(err)
+          db.close(t.end)
+        })
+      }
+    })
+  })
+})
+
+tape('length re-read with validation', function (t) {
+  var file = '/tmp/jacob-length.log'
+  var db = Log(file, {
+    blockSize: 64*1024,
+    validateRecord: (d) => {
+      try {
+        bipf.decode(d, 0)
+        return true
+      } catch (ex) {
+        return false
+      }
+    }
+  })
+
+  db.onReady(() => {
+    var result = []
+    
+    db.stream({seqs: false}).pipe({
+      paused: false,
+      write: function (e) { result.push(e) },
+      end: function() {
+        t.equal(result.length, 2)
+        db.close(t.end)
+      }
+    })
+  })
+})


### PR DESCRIPTION
This is an attempt to fix #11. As said in the issue I have looked over the code carefully and can't see where it should fail except if data becomes corrupt on write. Basically the log provided has 2 errors: corrupt bipf data and corrupt length information. Bipf has been super stable for me. I have never seen it fail to write data. And I tried to make async-flumelog as simple as possible, so that when it writes a record it literally just does buffer write of length + buffer copy of the actual data. Also considering this happened on 1 machine out of a bunch of manyverse machines makes me think this must be rather exceptional. We have run literally million of messages through this without any trouble.

What I *think* happened to jacobs log is that it became corrupt after about 300mb after which the rests is no good. If we had this in place my hunch in that it would have fixed the corruption and it would have continued fine.

Also because of the way we keep track of indexes, this corrupt data should not have made it to indexes because indexes rely on seq, which will only be set on write. So either the write is ok, or the write crashes and with this PR we will fix the log before any indexes sees the corrupt data. This should even be safe for own writes because things like EBT is dependant on indexes.

This PR will on load of the db check the latest block for 2 kinds of errors: messages error where a custom validate function must be supplied and a length check.

To test if you have the corrupted log run: `truncate -s 329777152 <PATH_TO>/log.bipf` which will truncate the log to where it started failing.

