### PR TITLE
Don't skip deleted data in stream

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -52,11 +52,8 @@ Stream.prototype._ready = function () {
 
 Stream.prototype._writeToSink = function (data) {
   if (this.values) {
-    if (data != null) // skip deleted
-    {
-      if (this.seqs) this.sink.write({ seq: this.cursor, value: data })
-      else this.sink.write(data)
-    }
+    if (this.seqs) this.sink.write({ seq: this.cursor, value: data })
+    else this.sink.write(data)
   }
   else
     this.sink.write(this.cursor)

--- a/test/delete.js
+++ b/test/delete.js
@@ -128,7 +128,7 @@ tape('stream delete', function(t) {
         db.onDrain(() => {
           db.stream({seqs: false}).pipe(collect(function (err, ary) {
             t.notOk(err)
-            t.deepEqual(ary, [b2])
+            t.deepEqual(ary, [null, b2])
             t.end()
           }))
         })


### PR DESCRIPTION
Before when streaming we would just skip deleted values. The problem with this is that if you have offset based indexes like in jitdb, then the offsets won't match after you delete stuff if you compare an old index with a new one. And we don't want to reindex everything, so instead just stream deleted values as null and let the receiving end filter. It has to do that anyway in get.